### PR TITLE
Rename rebench configuation

### DIFF
--- a/ast-vs-bc.conf
+++ b/ast-vs-bc.conf
@@ -76,14 +76,6 @@ artifact_review: true
 runs:
   max_invocation_time: 42000
 
-reporting:
-    rebenchdb:
-        # this url needs to point to the API endpoint
-        db_url: https://rebench.stefan-marr.de/rebenchdb
-        repo_url: https://github.com/smarr/awfy-runs
-        record_all: true # make sure everything is recorded
-        project_name: Are We Fast Yet
-
 # definition of benchmark suites
 benchmark_suites:
     som-steady:
@@ -92,49 +84,21 @@ benchmark_suites:
         iterations: *FAST_VM ## the number iterations measured
         location: awfy/benchmarks/SOM
         benchmarks: &BENCHMARKS
-            - DeltaBlue:
-                extra_args: 10000
-                codespeed_name: "[peak] DeltaBlue"
-            - Richards:
-                extra_args: 40
-                codespeed_name: "[peak] Richards"
-            - Json:
-                extra_args: 80
-                codespeed_name: "[peak] Json"
-            - CD:
-                extra_args: 250
-                codespeed_name: "[peak] CD"
-            - Havlak:
-                extra_args: 1500
-                codespeed_name: "[peak] Havlak"
+            - DeltaBlue: {extra_args: 10000}
+            - Richards:  {extra_args: 40}
+            - Json:      {extra_args: 80}
+            - CD:        {extra_args: 250}
+            - Havlak:    {extra_args: 1500}
 
-            - Bounce:
-                extra_args: 4000
-                codespeed_name: "[peak] Bounce"
-            - List:
-                extra_args: 1000
-                codespeed_name: "[peak] List"
-            - Mandelbrot:
-                extra_args: 750
-                codespeed_name: "[peak] Mandelbrot"
-            - NBody:
-                extra_args: 250000
-                codespeed_name: "[peak] NBody"
-            - Permute:
-                extra_args: 1500
-                codespeed_name: "[peak] Permute"
-            - Queens:
-                extra_args: 1000
-                codespeed_name: "[peak] Queens"
-            - Sieve:
-                extra_args: 2500
-                codespeed_name: "[peak] Sieve"
-            - Storage:
-                extra_args: 1000
-                codespeed_name: "[peak] Storage"
-            - Towers:
-                extra_args: 1000
-                codespeed_name: "[peak] Towers"
+            - Bounce:     {extra_args: 4000}
+            - List:       {extra_args: 1000}
+            - Mandelbrot: {extra_args: 750}
+            - NBody:      {extra_args: 250000}
+            - Permute:    {extra_args: 1500}
+            - Queens:     {extra_args: 1000}
+            - Sieve:      {extra_args: 2500}
+            - Storage:    {extra_args: 1000}
+            - Towers:     {extra_args: 1000}
 
     som-interp:
         gauge_adapter: RebenchLog
@@ -457,13 +421,6 @@ executors:
 
 
 experiments:
-    # test-remove-me:
-    #     executions:
-    #         - TruffleSOM-ast-HotspotCE-jit:
-    #             suites: [som-steady]
-    #         - TruffleSOM-bc-HotspotCE-jit:
-    #             suites: [som-steady]
-
     all-normal:
         executions:
             - TruffleSOM-ast-HotspotCE-jit:

--- a/run_rebench.sh
+++ b/run_rebench.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-rebench -d -v -f --setup-only --disable-data-reporting --experiment="Just building" codespeed.conf all ${1:-all-normal} s:*:List
-rebench -f --without-building -c --experiment="Every optim removed individually" codespeed.conf ${1:-all-normal} s:* 
+rebench -d -v -f --setup-only ast-vs-bc.conf all ${1:-all-normal} s:*:List
+rebench -f --without-building -c ast-vs-bc.conf ${1:-all-normal} s:* 


### PR DESCRIPTION
- rename rebench configuation
- remove reporting to ReBenchDB
- remove old codespeed_name info
- make config more compact